### PR TITLE
Add "react-native-email.d.ts" to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "module": "index.js",
     "types": "react-native-email.d.ts",
     "files": [
-        "index.js"
+        "index.js",
+        "react-native-email.d.ts"
     ],
     "scripts": {
         "test": "echo 'no tests'",


### PR DESCRIPTION
Typescript type definition was not included in the npm package. This PR fixes that.