### PR TITLE
fix: removed canOpenURL

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,13 +23,11 @@ async function sendEmail (to, { cc, bcc, subject, body } = {}) {
     }
   }
 
-  const supported = await Linking.canOpenURL(url)
+  return Linking.openURL(url).catch(() => handleError());
+}
 
-  if (!supported) {
-    return Promise.reject(new Error('Provided URL can not be handled'))
-  }
-
-  return Linking.openURL(url)
+function handleError() {
+  return Promise.reject(new Error('Provided URL can not be handled'));
 }
 
 export default sendEmail


### PR DESCRIPTION
Hi!

There's a problem with canOpenURL() function. It's returning false on Android 11 and iOS 14.8+  physical devices in contexts where openURL() will work (mailto: protocol for example). I think that's the reason behind this [issue](https://github.com/tiaanduplessis/react-native-email/issues/22)
You can read more about this Android 11 limitations [here](https://reactnative.dev/docs/linking) and on this [issue](https://github.com/facebook/react-native/issues/32311)

So i removed the canOpenURL() validation but i'm catching eventual errors with openURL().catch() 

It solves the issue with canOpenURL and still returning an error if somehow the url is wrong.


